### PR TITLE
feat: fish shell with vi keybindings and tooling improvements

### DIFF
--- a/modules/home/fish/default.nix
+++ b/modules/home/fish/default.nix
@@ -1,0 +1,7 @@
+{ ... }:
+{
+  programs.fish = {
+    enable = true;
+    interactiveShellInit = "fish_vi_key_bindings";
+  };
+}

--- a/modules/nixos/common/default.nix
+++ b/modules/nixos/common/default.nix
@@ -34,10 +34,13 @@ in
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
     ];
 
+    programs.fish.enable = true;
+
     users.users.aiden = {
       uid = 1000;
       initialPassword = "password";
       isNormalUser = true;
+      shell = pkgs.fish;
       extraGroups = [
         "wheel"
         "disk"

--- a/systems/x86_64-linux/mike/default.nix
+++ b/systems/x86_64-linux/mike/default.nix
@@ -35,7 +35,7 @@
       scanner.enable = true;
       desktop.enable = true;
       gaming = {
-        games.oblivionSync.enable = true;
+        games.oblivionSync.enable = false;
         steam.enable = true;
         moonlight.client.enable = true;
       };

--- a/systems/x86_64-linux/mike/packages.nix
+++ b/systems/x86_64-linux/mike/packages.nix
@@ -10,5 +10,6 @@ params@{
   environment.systemPackages = with pkgs; [
     naps2
     antigravity-fhs
+    gh
   ];
 }


### PR DESCRIPTION
Add fish shell as default with vi keybindings and improve developer tooling.

Sets up fish shell with vi keybindings for better command-line ergonomics, adds GitHub CLI for repository operations, and fixes a broken oblivion-sync service.

## Shell Configuration

- Set fish as default shell for aiden user
- Add home-manager fish module with vi keybindings enabled
- Provides better interactive shell experience with familiar vim navigation

## Tooling

- Add gh CLI to mike for GitHub operations
- Enables PR creation, issue management, and other GitHub workflows from command line

## Bug Fix

- Disable oblivion-sync on mike (syncthing source directory /var/lib/syncthing/Oblivion doesn't exist)
- Prevents service failure on boot