### PR TITLE
Extract restic-b2 backup configuration into dedicated module

### DIFF
--- a/modules/hosts/bes/bes.nix
+++ b/modules/hosts/bes/bes.nix
@@ -113,14 +113,25 @@
             ];
           };
 
-          # UID-based bandwidth shaping for restic via tc HTB + iptables fwmark.
+          # UID-based bandwidth shaping for restic via tc HTB + nftables fwmark.
           # Daytime (0700-2200): 5 Mbit/s upload cap. Nighttime: effectively unlimited.
+          networking.nftables.enable = true;
+          networking.nftables.tables.restic-mark = {
+            family = "ip";
+            content = ''
+              chain output-mark {
+                type filter hook output priority mangle; policy accept;
+                meta skuid restic meta mark set 0x00000001
+              }
+            '';
+          };
+
           systemd.services.restic-tc-setup = {
             description = "tc bandwidth shaping for restic (UID-based)";
             after = [ "network-online.target" ];
             wants = [ "network-online.target" ];
             wantedBy = [ "multi-user.target" ];
-            path = with pkgs; [ iproute2 iptables ];
+            path = [ pkgs.iproute2 ];
             serviceConfig = {
               Type = "oneshot";
               RemainAfterExit = true;
@@ -138,13 +149,9 @@
 
                 # Steer fwmark 0x1 → class 1:20 (restic)
                 tc filter add dev "$IFACE" parent 1: protocol ip handle 1 fw classid 1:20
-
-                # Mark outgoing packets from restic UID
-                iptables -t mangle -A OUTPUT -m owner --uid-owner restic -j MARK --set-mark 1
               '';
               ExecStop = pkgs.writeShellScript "restic-tc-teardown" ''
                 IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
-                iptables -t mangle -D OUTPUT -m owner --uid-owner restic -j MARK --set-mark 1 || true
                 tc qdisc del dev "$IFACE" root || true
               '';
             };

--- a/modules/hosts/bes/bes.nix
+++ b/modules/hosts/bes/bes.nix
@@ -24,6 +24,7 @@
     ])
     ++ [
       config.flake.modules.nixos.immich
+      config.flake.modules.nixos.restic-b2
     ]
     ++ [
       config.flake.modules.nixos."cli-base"
@@ -77,125 +78,6 @@
 
           age.secrets.opencode-env.file = "${inputs.self.outPath}/secrets/opencode-env.age";
           age.secrets.slskd.file = "${inputs.self.outPath}/secrets/slskd";
-          age.secrets.restic-b2-env.file = "${inputs.self.outPath}/secrets/restic-b2-env.age";
-          age.secrets.restic-b2-env.owner = "restic";
-          age.secrets.restic-b2-password.file = "${inputs.self.outPath}/secrets/restic-b2-password.age";
-          age.secrets.restic-b2-password.owner = "restic";
-
-          users.users.restic = {
-            isSystemUser = true;
-            group = "restic";
-            # immich group gives read access to /media/t7/photos (immich-owned files)
-            extraGroups = [ "immich" ];
-          };
-          users.groups.restic = {};
-
-          services.restic.backups.b2 = {
-            user = "restic";
-            paths = [
-              "/media/t7/photos"
-              "/srv/media/Music/library/Cocteau Twins/1993 - Four-Calendar Café"
-            ];
-            repository = "s3:s3.eu-central-003.backblazeb2.com/backup-uwdcrk";
-            environmentFile = config.age.secrets.restic-b2-env.path;
-            passwordFile = config.age.secrets.restic-b2-password.path;
-            initialize = true;
-            createWrapper = true;
-            timerConfig = {
-              OnCalendar = "daily";
-              Persistent = "true";
-            };
-            pruneOpts = [
-              "--keep-daily 7"
-              "--keep-weekly 4"
-              "--keep-monthly 6"
-              "--keep-yearly 2"
-            ];
-          };
-
-          # UID-based bandwidth shaping for restic via tc HTB + nftables fwmark.
-          # Daytime (0700-2200): 5 Mbit/s upload cap. Nighttime: effectively unlimited.
-          networking.nftables.enable = true;
-          networking.nftables.tables.restic-mark = {
-            family = "ip";
-            content = ''
-              chain output-mark {
-                type filter hook output priority mangle; policy accept;
-                meta skuid restic meta mark set 0x00000001
-              }
-            '';
-          };
-
-          systemd.services.restic-tc-setup = {
-            description = "tc bandwidth shaping for restic (UID-based)";
-            after = [ "network-online.target" ];
-            wants = [ "network-online.target" ];
-            wantedBy = [ "multi-user.target" ];
-            path = [ pkgs.iproute2 ];
-            serviceConfig = {
-              Type = "oneshot";
-              RemainAfterExit = true;
-              ExecStart = pkgs.writeShellScript "restic-tc-setup" ''
-                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
-
-                # HTB root qdisc — default traffic → class 1:10 (unlimited)
-                tc qdisc add dev "$IFACE" root handle 1: htb default 10
-
-                # Bandwidth classes
-                tc class add dev "$IFACE" parent 1:  classid 1:1  htb rate 1gbit ceil 1gbit
-                tc class add dev "$IFACE" parent 1:1 classid 1:10 htb rate 1gbit ceil 1gbit
-                # Restic class — starts unlimited; restic-tc-day.timer throttles it at 07:00
-                tc class add dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
-
-                # Steer fwmark 0x1 → class 1:20 (restic)
-                tc filter add dev "$IFACE" parent 1: protocol ip handle 1 fw classid 1:20
-              '';
-              ExecStop = pkgs.writeShellScript "restic-tc-teardown" ''
-                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
-                tc qdisc del dev "$IFACE" root || true
-              '';
-            };
-          };
-
-          systemd.services.restic-tc-day = {
-            description = "Throttle restic to 5 Mbit (daytime 0700-2200)";
-            after = [ "restic-tc-setup.service" ];
-            requires = [ "restic-tc-setup.service" ];
-            path = [ pkgs.iproute2 ];
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = pkgs.writeShellScript "restic-tc-day" ''
-                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
-                tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 5mbit ceil 5mbit
-              '';
-            };
-          };
-
-          systemd.timers.restic-tc-day = {
-            description = "Throttle restic at 07:00";
-            wantedBy = [ "timers.target" ];
-            timerConfig = { OnCalendar = "*-*-* 07:00:00"; Persistent = true; };
-          };
-
-          systemd.services.restic-tc-night = {
-            description = "Unthrottle restic (nighttime 2200-0700)";
-            after = [ "restic-tc-setup.service" ];
-            requires = [ "restic-tc-setup.service" ];
-            path = [ pkgs.iproute2 ];
-            serviceConfig = {
-              Type = "oneshot";
-              ExecStart = pkgs.writeShellScript "restic-tc-night" ''
-                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
-                tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
-              '';
-            };
-          };
-
-          systemd.timers.restic-tc-night = {
-            description = "Unthrottle restic at 22:00";
-            wantedBy = [ "timers.target" ];
-            timerConfig = { OnCalendar = "*-*-* 22:00:00"; Persistent = true; };
-          };
 
           programs.mosh.enable = true;
 

--- a/modules/hosts/bes/bes.nix
+++ b/modules/hosts/bes/bes.nix
@@ -78,9 +78,20 @@
           age.secrets.opencode-env.file = "${inputs.self.outPath}/secrets/opencode-env.age";
           age.secrets.slskd.file = "${inputs.self.outPath}/secrets/slskd";
           age.secrets.restic-b2-env.file = "${inputs.self.outPath}/secrets/restic-b2-env.age";
+          age.secrets.restic-b2-env.owner = "restic";
           age.secrets.restic-b2-password.file = "${inputs.self.outPath}/secrets/restic-b2-password.age";
+          age.secrets.restic-b2-password.owner = "restic";
+
+          users.users.restic = {
+            isSystemUser = true;
+            group = "restic";
+            # immich group gives read access to /media/t7/photos (immich-owned files)
+            extraGroups = [ "immich" ];
+          };
+          users.groups.restic = {};
 
           services.restic.backups.b2 = {
+            user = "restic";
             paths = [
               "/media/t7/photos"
               "/srv/media/Music/library/Cocteau Twins/1993 - Four-Calendar Café"
@@ -100,6 +111,83 @@
               "--keep-monthly 6"
               "--keep-yearly 2"
             ];
+          };
+
+          # UID-based bandwidth shaping for restic via tc HTB + iptables fwmark.
+          # Daytime (0700-2200): 5 Mbit/s upload cap. Nighttime: effectively unlimited.
+          systemd.services.restic-tc-setup = {
+            description = "tc bandwidth shaping for restic (UID-based)";
+            after = [ "network-online.target" ];
+            wants = [ "network-online.target" ];
+            wantedBy = [ "multi-user.target" ];
+            path = with pkgs; [ iproute2 iptables ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = pkgs.writeShellScript "restic-tc-setup" ''
+                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+
+                # HTB root qdisc — default traffic → class 1:10 (unlimited)
+                tc qdisc add dev "$IFACE" root handle 1: htb default 10
+
+                # Bandwidth classes
+                tc class add dev "$IFACE" parent 1:  classid 1:1  htb rate 1gbit ceil 1gbit
+                tc class add dev "$IFACE" parent 1:1 classid 1:10 htb rate 1gbit ceil 1gbit
+                # Restic class — starts unlimited; restic-tc-day.timer throttles it at 07:00
+                tc class add dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
+
+                # Steer fwmark 0x1 → class 1:20 (restic)
+                tc filter add dev "$IFACE" parent 1: protocol ip handle 1 fw classid 1:20
+
+                # Mark outgoing packets from restic UID
+                iptables -t mangle -A OUTPUT -m owner --uid-owner restic -j MARK --set-mark 1
+              '';
+              ExecStop = pkgs.writeShellScript "restic-tc-teardown" ''
+                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+                iptables -t mangle -D OUTPUT -m owner --uid-owner restic -j MARK --set-mark 1 || true
+                tc qdisc del dev "$IFACE" root || true
+              '';
+            };
+          };
+
+          systemd.services.restic-tc-day = {
+            description = "Throttle restic to 5 Mbit (daytime 0700-2200)";
+            after = [ "restic-tc-setup.service" ];
+            requires = [ "restic-tc-setup.service" ];
+            path = [ pkgs.iproute2 ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = pkgs.writeShellScript "restic-tc-day" ''
+                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+                tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 5mbit ceil 5mbit
+              '';
+            };
+          };
+
+          systemd.timers.restic-tc-day = {
+            description = "Throttle restic at 07:00";
+            wantedBy = [ "timers.target" ];
+            timerConfig = { OnCalendar = "*-*-* 07:00:00"; Persistent = true; };
+          };
+
+          systemd.services.restic-tc-night = {
+            description = "Unthrottle restic (nighttime 2200-0700)";
+            after = [ "restic-tc-setup.service" ];
+            requires = [ "restic-tc-setup.service" ];
+            path = [ pkgs.iproute2 ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = pkgs.writeShellScript "restic-tc-night" ''
+                IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+                tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
+              '';
+            };
+          };
+
+          systemd.timers.restic-tc-night = {
+            description = "Unthrottle restic at 22:00";
+            wantedBy = [ "timers.target" ];
+            timerConfig = { OnCalendar = "*-*-* 22:00:00"; Persistent = true; };
           };
 
           programs.mosh.enable = true;

--- a/modules/hosts/bes/restic-b2.nix
+++ b/modules/hosts/bes/restic-b2.nix
@@ -48,7 +48,7 @@
       # Uses tc class change to adjust the rate in-place without interrupting uploads.
       networking.nftables.enable = true;
       networking.nftables.tables.restic-mark = {
-        family = "ip";
+        family = "inet";
         content = ''
           chain output-mark {
             type filter hook output priority mangle; policy accept;
@@ -68,6 +68,7 @@
           RemainAfterExit = true;
           ExecStart = pkgs.writeShellScript "restic-tc-setup" ''
             IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+            tc qdisc del dev "$IFACE" root 2>/dev/null || true
             tc qdisc add dev "$IFACE" root handle 1: htb default 10
             tc class add dev "$IFACE" parent 1:  classid 1:1  htb rate 1gbit ceil 1gbit
             tc class add dev "$IFACE" parent 1:1 classid 1:10 htb rate 1gbit ceil 1gbit

--- a/modules/hosts/bes/restic-b2.nix
+++ b/modules/hosts/bes/restic-b2.nix
@@ -15,8 +15,9 @@
       users.users.restic = {
         isSystemUser = true;
         group = "restic";
-        # immich group gives read access to /media/t7/photos (immich-owned files)
-        extraGroups = [ "immich" ];
+        # immich group: read access to /media/t7/photos
+        # media group: read access to /srv/media/Music
+        extraGroups = [ "immich" "media" ];
       };
       users.groups.restic = { };
 

--- a/modules/hosts/bes/restic-b2.nix
+++ b/modules/hosts/bes/restic-b2.nix
@@ -1,0 +1,124 @@
+{ inputs, ... }:
+{
+  flake.modules.nixos.restic-b2 =
+    { config, pkgs, ... }:
+    {
+      age.secrets.restic-b2-env = {
+        file = "${inputs.self.outPath}/secrets/restic-b2-env.age";
+        owner = "restic";
+      };
+      age.secrets.restic-b2-password = {
+        file = "${inputs.self.outPath}/secrets/restic-b2-password.age";
+        owner = "restic";
+      };
+
+      users.users.restic = {
+        isSystemUser = true;
+        group = "restic";
+        # immich group gives read access to /media/t7/photos (immich-owned files)
+        extraGroups = [ "immich" ];
+      };
+      users.groups.restic = { };
+
+      services.restic.backups.b2 = {
+        user = "restic";
+        paths = [
+          "/media/t7/photos"
+          "/srv/media/Music/library/Cocteau Twins/1993 - Four-Calendar Café"
+        ];
+        repository = "s3:s3.eu-central-003.backblazeb2.com/backup-uwdcrk";
+        environmentFile = config.age.secrets.restic-b2-env.path;
+        passwordFile = config.age.secrets.restic-b2-password.path;
+        initialize = true;
+        createWrapper = true;
+        timerConfig = {
+          OnCalendar = "daily";
+          Persistent = "true";
+        };
+        pruneOpts = [
+          "--keep-daily 7"
+          "--keep-weekly 4"
+          "--keep-monthly 6"
+          "--keep-yearly 2"
+        ];
+      };
+
+      # UID-based bandwidth shaping via tc HTB + nftables fwmark.
+      # Daytime (0700-2200): 5 Mbit/s upload cap. Nighttime: effectively unlimited.
+      # Uses tc class change to adjust the rate in-place without interrupting uploads.
+      networking.nftables.enable = true;
+      networking.nftables.tables.restic-mark = {
+        family = "ip";
+        content = ''
+          chain output-mark {
+            type filter hook output priority mangle; policy accept;
+            meta skuid restic meta mark set 0x00000001
+          }
+        '';
+      };
+
+      systemd.services.restic-tc-setup = {
+        description = "tc bandwidth shaping for restic (UID-based)";
+        after = [ "network-online.target" ];
+        wants = [ "network-online.target" ];
+        wantedBy = [ "multi-user.target" ];
+        path = [ pkgs.iproute2 ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          ExecStart = pkgs.writeShellScript "restic-tc-setup" ''
+            IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+            tc qdisc add dev "$IFACE" root handle 1: htb default 10
+            tc class add dev "$IFACE" parent 1:  classid 1:1  htb rate 1gbit ceil 1gbit
+            tc class add dev "$IFACE" parent 1:1 classid 1:10 htb rate 1gbit ceil 1gbit
+            tc class add dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
+            tc filter add dev "$IFACE" parent 1: protocol ip handle 1 fw classid 1:20
+          '';
+          ExecStop = pkgs.writeShellScript "restic-tc-teardown" ''
+            IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+            tc qdisc del dev "$IFACE" root || true
+          '';
+        };
+      };
+
+      systemd.services.restic-tc-day = {
+        description = "Throttle restic to 5 Mbit (daytime 0700-2200)";
+        after = [ "restic-tc-setup.service" ];
+        requires = [ "restic-tc-setup.service" ];
+        path = [ pkgs.iproute2 ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "restic-tc-day" ''
+            IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+            tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 5mbit ceil 5mbit
+          '';
+        };
+      };
+
+      systemd.timers.restic-tc-day = {
+        description = "Throttle restic at 07:00";
+        wantedBy = [ "timers.target" ];
+        timerConfig = { OnCalendar = "*-*-* 07:00:00"; Persistent = true; };
+      };
+
+      systemd.services.restic-tc-night = {
+        description = "Unthrottle restic (nighttime 2200-0700)";
+        after = [ "restic-tc-setup.service" ];
+        requires = [ "restic-tc-setup.service" ];
+        path = [ pkgs.iproute2 ];
+        serviceConfig = {
+          Type = "oneshot";
+          ExecStart = pkgs.writeShellScript "restic-tc-night" ''
+            IFACE=$(ip route show default | awk '/default/ {print $5; exit}')
+            tc class change dev "$IFACE" parent 1:1 classid 1:20 htb rate 1gbit ceil 1gbit
+          '';
+        };
+      };
+
+      systemd.timers.restic-tc-night = {
+        description = "Unthrottle restic at 22:00";
+        wantedBy = [ "timers.target" ];
+        timerConfig = { OnCalendar = "*-*-* 22:00:00"; Persistent = true; };
+      };
+    };
+}


### PR DESCRIPTION
## Summary
Refactored the restic B2 backup configuration from the `bes.nix` host file into a standalone reusable NixOS module. This improves code organization and maintainability by separating backup concerns from the main host configuration.

## Key Changes
- **New module**: Created `modules/hosts/bes/restic-b2.nix` containing:
  - Restic B2 backup service configuration with daily scheduling and retention policies
  - Age-encrypted secrets management for B2 credentials
  - Dedicated `restic` system user with appropriate group memberships
  - Bandwidth shaping via `tc` (traffic control) with nftables marking:
    - Daytime (07:00-22:00): 5 Mbit/s upload cap
    - Nighttime (22:00-07:00): Unlimited (1 Gbit/s)
  - Systemd services and timers for bandwidth throttling

- **Updated host config**: Removed restic configuration from `bes.nix` and imported the new module via `config.flake.modules.nixos.restic-b2`

## Notable Implementation Details
- Uses UID-based traffic control via nftables `fwmark` to isolate restic traffic
- Bandwidth shaping implemented with `tc` HTB (Hierarchical Token Bucket) queuing discipline
- Dynamic interface detection to support different network configurations
- Graceful cleanup of tc rules on service stop
- Persistent timers ensure bandwidth limits are reapplied after system reboot

https://claude.ai/code/session_0192vCSUUBvR8rZUE2SUYk4p